### PR TITLE
Add tests for sentenceCased() helper

### DIFF
--- a/Tests/GitTests/StringExtensionTests.swift
+++ b/Tests/GitTests/StringExtensionTests.swift
@@ -1,0 +1,10 @@
+@testable import Git
+import XCTest
+
+final class StringExtensionTests: XCTestCase {
+  func testSentenceCased() {
+    XCTAssertEqual("hello world".sentenceCased(), "Hello world")
+    XCTAssertEqual("foo? bar.".sentenceCased(), "Foo? Bar.")
+    XCTAssertEqual("A Title-Cased String".sentenceCased(), "A title-cased string")
+  }
+}


### PR DESCRIPTION
- Fixes an issue where the capitalisation after the first word was not changed.
- Fixes an exception that could be thrown when the last sentence in the string does not end with a whitespace character.