### PR TITLE
Make remote initializer public

### DIFF
--- a/Sources/Git/Remote.swift
+++ b/Sources/Git/Remote.swift
@@ -4,7 +4,7 @@ public struct Remote {
   let _remote: ManagedGitPointer
   let repository: Repository
 
-  init(named name: String, in repository: Repository) throws {
+  public init(named name: String, in repository: Repository) throws {
     let callbacks = GitCallbacks(free: git_remote_free)
     self._remote = try .create(withCallbacks: callbacks, operation: "git_remote_lookup") { pointer in
       repository.withUnsafePointer { repository in


### PR DESCRIPTION
The remote initializer is not public which makes fetching repositories impossible